### PR TITLE
 Ensure line is closed so that we can record repeatedly record without having to restart the entire program.

### DIFF
--- a/src/com/phronemophobic/whisper.clj
+++ b/src/com/phronemophobic/whisper.clj
@@ -166,7 +166,6 @@
              (.write out buf 0 bytes-read)
              (recur))))
        (let [result (.toByteArray out)]
-         (.flush line)
          (.close line)
          result)))))
 

--- a/src/com/phronemophobic/whisper.clj
+++ b/src/com/phronemophobic/whisper.clj
@@ -165,7 +165,10 @@
            (when (pos? bytes-read)
              (.write out buf 0 bytes-read)
              (recur))))
-       (.toByteArray out)))))
+       (let [result (.toByteArray out)]
+         (.flush line)
+         (.close line)
+         result)))))
 
 (defn record-and-transcribe
   "Starts recording audio from the default system microphone.


### PR DESCRIPTION
I made a very basic voice typing program with whisper.clj and noticed that (on Linux at least) it would complain if you tried to make a second recording, reporting that the no viable line could be found. 

This is the work-around that I got to work.

There might be a better way to go about it.